### PR TITLE
smtp password creation and domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ FROM ruby:2.6.3
 LABEL maintainer="ivann.laruelle@gmail.com"
 
 ENV RAILS_ENV=production
+ENV DECIDIM_VERSION=0.22.0
 
 RUN apt-get update && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && apt-get install -y nodejs imagemagick yarn libicu-dev postgresql-client openssl nano bash curl git && apt-get autoremove && \
     mkdir -m 770 /home/docker-user && \
-    gem install bundler && gem install bootsnap && gem install listen && mkdir -m 770 /decidim-app && gem install decidim && decidim /decidim-app
+    gem install bundler && gem install bootsnap && gem install listen && mkdir -m 770 /decidim-app && gem install decidim -v ${DECIDIM_VERSION} && decidim /decidim-app
 
 WORKDIR /decidim-app
 
@@ -20,7 +21,7 @@ EXPOSE 3000
 
 RUN echo "gem 'omniauth-cas'" >> Gemfile && echo "gem 'omniauth-facebook'" >> Gemfile && echo "gem 'omniauth-google-oauth2'" >> Gemfile && echo "gem 'omniauth-twitter'" >> Gemfile && \
     echo "gem 'figaro'" >> Gemfile && echo "gem 'daemons'" >> Gemfile && echo "gem 'delayed_job_active_record'" >> Gemfile && echo "gem 'wkhtmltopdf-binary'" >> Gemfile && \
-    echo "gem 'wicked_pdf'" >> Gemfile && bundle install && echo "gem 'decidim-consultations'" >> Gemfile && echo "gem 'decidim-initiatives'" >> Gemfile && \
+    echo "gem 'wicked_pdf'" >> Gemfile && echo "gem 'decidim-consultations', '${DECIDIM_VERSION}'" >> Gemfile &&  echo "gem 'decidim-initiatives', '${DECIDIM_VERSION}'" >> Gemfile && \
     bundle install
 
 COPY entrycheck /entrycheck.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
 
   db:
-    image: postgres
+    image: postgres:13
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_USER=decidim
@@ -12,19 +12,26 @@ services:
       - db-data:/var/lib/postgresql/data
 
   decidim:
+    build: .
     image: larueli/decidim-nonroot
     user: "10520:0"
     ports:
-      - "3001:3000"
+      - "80:3000"
     volumes:
       - decidim-uploads:/decidim-app/public/uploads
       - decidim-config:/decidim-app/config
     environment:
       # Decidim needs connection as superuser on postgres
-      - DATABASE_URL=postgres://postgres:myadminsecretpassword@db/decidim
-      - RAILS_MASTER_KEY=34d3cc7c5305dde06865acfa473716cd
+      - DATABASE_URL=postgres://decidim:mysecretpassword@db/decidim
+#      - RAILS_MASTER_KEY=34d3cc7c5305dde06865acfa473716cd
       - RAILS_ENV=production
       - RAILS_SERVE_STATIC_FILES=true
+      # This is necesary to encrypt passwords
+      - SECRET_KEY_BASE=23203391c825c600801d8f8657be32957b143291e1024e047cb04d0ba435c7e1a01db3d23d88fa0aaf77549a2845bfac3709f02171f0afc1cbd24f09a4fe1552
+      # Logs
+      - RAILS_LOG_TO_STDOUT=true
+      # This is necesary even if other SMTP settings are set in organization.
+      - SMTP_DOMAIN=somedomain.com
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: larueli/decidim-nonroot
     user: "10520:0"
     ports:
-      - "80:3000"
+      - "3000:3000"
     volumes:
       - decidim-uploads:/decidim-app/public/uploads
       - decidim-config:/decidim-app/config


### PR DESCRIPTION
Hi, some suggestions:

- Fixing Postgres version in docker-compose to avoid a mess when you have previous versions installed.
- For some reason redirection for organizations is not woking with a port different than 80 in localhost.
- I've found that SECRET_KEY_BASE is needed for the encryption of passwords. Particularly SMTP password in organization creation.
- Also without some value in SMTP_DOMAIN, SMTP won't work.

And I had to comment out RAILS_MASTER_KEY to fix #5 